### PR TITLE
Update section 3 of introduction.html to remove inaccurate advice

### DIFF
--- a/introduction.html
+++ b/introduction.html
@@ -44,7 +44,7 @@ h2{text-align:left;text-transform:inherit}
 <p><code>&lt;!DOCTYPE html></code>
 </blockquote>
 
-<p>Upgrading to the <abbr>HTML5</abbr> doctype won&#8217;t break your existing markup, because all the tags defined in HTML 4 are still supported in <abbr>HTML5</abbr>. But it will allow you to use &mdash; and validate &mdash; new semantic elements like <code>&lt;article></code>, <code>&lt;section></code>, <code>&lt;header></code>, and <code>&lt;footer></code>. You&#8217;ll learn all about these new elements in <a href=semantics.html>Chapter 3</a>.
+<p>Upgrading to the <abbr>HTML5</abbr> doctype is straightforward. You will most likely need to make a few minor alterations to your markup, but these are easy as <abbr>HTML5</abbr> is designed to be a natural progression from <abbr>HTML</abbr> 4. But it will allow you to use &mdash; and validate &mdash; new semantic elements like <code>&lt;article></code>, <code>&lt;section></code>, <code>&lt;header></code>, and <code>&lt;footer></code>. You&#8217;ll learn all about these new elements in <a href=semantics.html>Chapter 3</a>.
 
 <h2 id=four>4. It already works</h2>
 


### PR DESCRIPTION
Update section 3 of introduction.html to remove inaccurate advice to place HTML 5 doctypes on unaltered HTML 4 documents.

This pull request is related to issue #1.
